### PR TITLE
Unimarc interface

### DIFF
--- a/classes/AddedEntry.php
+++ b/classes/AddedEntry.php
@@ -14,10 +14,13 @@ class AddedEntry extends BaseTab {
     $debug = FALSE; // ($record->field == '052');
     if ($debug)
       error_log('location: ' . $record->location);
+    // Query in form of "052ind1_GeographicClassification_codeSource_ss
+    // Or starting with "0522_GeographicClassification_source_ss:scheme"
 
+    // %%22 is actually %22 in the URL encoding, which is a double quote (")
     if ($record->location == 'ind1') {
       $record->q = sprintf('%s:%%22%s%%22', $ind1, $record->scheme);
-    } else if ($record->location == '$2') {
+    } elseif ($record->location == '$2') {
       if ($record->scheme == 'undetectable') {
         $record->q = sprintf('%s:%%22Source specified in subfield \$2%%22 NOT %s:*', $ind1, $subfield2);
       } else {
@@ -181,20 +184,30 @@ class AddedEntry extends BaseTab {
   }
 
   /**
-   * @param $record
-   * @param $base
+   * This method is used to create facets for a given field. The method sets the facet and facet2 properties of the
+   * classificationRecord object.
+   * @param object $classificationRecord Represents a bibliographic field, result of the classification process
+   *                                     (not to mistake for a bibliographic record).
+   * @param string $base The base name for the facet.
    */
-  protected function createFacets(&$record, $base) {
-    $record->facet = $base . '_ss';
+  protected function createFacets(object &$classificationRecord, string $base) {
+    $classificationRecord->facet = $base . '_ss';
 
-    if (isset($record->abbreviation4solr)
-        && $record->abbreviation4solr != ''
-        && in_array($record->abbreviation4solr, $this->solr()->getSolrFields())) {
-      $record->facet2 = $base . '_' . $record->abbreviation4solr . '_ss';
-    } elseif (isset($record->abbreviation)
-        && $record->abbreviation != ''
-        && in_array($record->abbreviation, $this->solr()->getSolrFields())) {
-      $record->facet2 = $base . '_' . $record->abbreviation . '_ss';
+    // The main difference between abbreviation and abbreviation4solr is that the latter gets stripped of
+    // special characters or whitespaces.
+    // This part with abbreviations is supposed to target the indexFieldsWithSchemas part of the Solr indexing in
+    // the qa-catalogue tool.
+    if (isset($classificationRecord->abbreviation4solr)
+        && $classificationRecord->abbreviation4solr != ''
+        && in_array($classificationRecord->abbreviation4solr, $this->solr()->getSolrFields())) {
+      $classificationRecord->facet2 = $base . '_' . $classificationRecord->abbreviation4solr . '_ss';
+      return;
+    }
+
+    if (isset($classificationRecord->abbreviation)
+        && $classificationRecord->abbreviation != ''
+        && in_array($classificationRecord->abbreviation, $this->solr()->getSolrFields())) {
+      $classificationRecord->facet2 = $base . '_' . $classificationRecord->abbreviation . '_ss';
     }
   }
 

--- a/classes/Authorities.php
+++ b/classes/Authorities.php
@@ -74,7 +74,7 @@ class Authorities extends AddedEntry {
         '811' => 'Series Added Entry - Meeting Name',
         '830' => 'Series Added Entry - Uniform Title'
       ];
-    } else if ($this->catalogue->getSchemaType() == 'PICA') {
+    } elseif ($this->catalogue->getSchemaType() == 'PICA') {
       $fields = [
         '022A' => 'Werktitel und sonstige unterscheidende Merkmale des Werks',
         '022A/01' => 'Weiterer Werktitel und sonstige unterscheidende Merkmale',
@@ -97,7 +97,28 @@ class Authorities extends AddedEntry {
         '037Q' => 'Beschreibung des Einbands',
         '037R' => 'Buchschmuck (Druckermarken, Vignetten, Zierleisten etc.)',
       ];
+    } elseif ($this->catalogue->getSchemaType() == 'UNIMARC') {
+      $fields = [
+        '500' => 'PREFFERRED ACCESS POINT',
+        '501' => 'CONVENTIONAL PREFERRED TITLE',
+        '506' => 'PREFERRED ACCESS POINT – IDENTIFICATION OF A WORK',
+        '507' => 'PREFERRED ACCESS POINT – IDENTIFICATION OF AN EXPRESSION',
+        '576' => 'NAME / ACCESS POINT– IDENTIFICATION OF A WORK',
+        '577' => 'NAME / ACCESS POINT– IDENTIFICATION OF AN EXPRESSION',
+        '620' => 'PLACE AND DATE OF PUBLICATION, PERFORMANCE, ETC.',
+        '700' => 'PERSONAL NAME – PRIMARY RESPONSIBILITY',
+        '701' => 'PERSONAL NAME – ALTERNATIVE RESPONSIBILITY',
+        '702' => 'PERSONAL NAME – SECONDARY RESPONSIBILITY',
+        '710$ind1=0' => 'CORPORATE BODY NAME – PRIMARY RESPONSIBILITY',
+        '711$ind1=0' => 'CORPORATE BODY NAME – ALTERNATIVE RESPONSIBILITY',
+        '712$ind1=0' => 'CORPORATE BODY NAME – SECONDARY RESPONSIBILITY',
+        '710$ind1=1' => 'MEETING BODY NAME – PRIMARY RESPONSIBILITY',
+        '711$ind1=1' => 'MEETING BODY NAME – ALTERNATIVE RESPONSIBILITY',
+        '712$ind1=1' => 'MEETING BODY NAME – SECONDARY RESPONSIBILITY',
+        '730' => 'NAME – ENTITY RESPONSIBLE',
+        ];
     }
+    // Is this even needed?
     $smarty->assign('fields', $fields);
     $smarty->assign('fieldHierarchy', $this->getFieldHierarchy());
 
@@ -106,112 +127,164 @@ class Authorities extends AddedEntry {
       $byRecordsFile = $this->getFilePath('authorities-by-field.csv');
     }
 
-    if (file_exists($byRecordsFile)) {
-      $header = [];
-      $records = [];
-      $in = fopen($byRecordsFile, "r");
-      while (($line = fgets($in)) != false) {
-        $values = str_getcsv($line);
-        if (empty($header)) {
-          $header = $values;
-        } else {
-          $record = (object)array_combine($header, $values);
-          $record->q = '*:*';
-          if ($this->catalogue->getSchemaType() == 'MARC21') {
-            if ($record->field == '100') {
-              $this->createFacets($record, '100a_MainPersonalName_personalName');
-              $this->subfield0or2($record, 'MainPersonalName');
-            } else if ($record->field == '110') {
-              $this->createFacets($record, '110a_MainCorporateName');
-              $this->subfield0or2($record, 'MainCorporateName');
-            } else if ($record->field == '111') {
-              $this->createFacets($record, '111a_MainMeetingName');
-              $this->subfield0or2($record, 'MainMeetingName');
-            } else if ($record->field == '130') {
-              $this->createFacets($record, '130a_MainUniformTitle');
-              $this->subfield0or2($record, 'MainUniformTitle');
-            } else if ($record->field == '700') {
-              $this->createFacets($record, '700a_AddedPersonalName_personalName');
-              $this->subfield0or2($record, 'AddedPersonalName');
-            } else if ($record->field == '710') {
-              $this->createFacets($record, '710a_AddedCorporateName');
-              $this->subfield0or2($record, 'AddedCorporateName');
-            } else if ($record->field == '711') {
-              $this->createFacets($record, '711a_AddedMeetingName');
-              $this->subfield0or2($record, 'AddedMeetingName');
-            } else if ($record->field == '720') {
-              $this->createFacets($record, '720a_UncontrolledName');
-              // $this->subfield0or2($record, '1000_MainPersonalName_authorityRecordControlNumber_organizationCode_ss', '1002_MainPersonalName_source_ss');
-            } else if ($record->field == '730') {
-              $this->createFacets($record, '730a_AddedUniformTitle');
-              $this->subfield0or2($record, 'AddedUniformTitle');
-            } else if ($record->field == '740') {
-              $this->createFacets($record, '740a_AddedUncontrolledRelatedOrAnalyticalTitle');
-              // $this->subfield0or2($record, '1000_MainPersonalName_authorityRecordControlNumber_organizationCode_ss', '1002_MainPersonalName_source_ss');
-            } else if ($record->field == '751') {
-              $this->createFacets($record, '751a_AddedGeographicName');
-              // $this->subfield0or2($record, '1000_MainPersonalName_authorityRecordControlNumber_organizationCode_ss', '1002_MainPersonalName_source_ss');
-            } else if ($record->field == '752') {
-              $this->createFacets($record, '752a_HierarchicalGeographic_country');
-              $this->subfield0or2($record, 'HierarchicalGeographic');
-            } else if ($record->field == '753') {
-              $this->createFacets($record, '753a_SystemRequirement_machineModel');
-              // $this->subfield0or2($record, '1000_MainPersonalName_authorityRecordControlNumber_organizationCode_ss', '1002_MainPersonalName_source_ss');
-            } else if ($record->field == '754') {
-              $this->createFacets($record, '754a_TaxonomicIdentification_name');
-              $this->subfield0or2($record, 'TaxonomicIdentification');
-            } else if ($record->field == '800') {
-              $this->createFacets($record, '800a_SeriesAddedPersonalName_personalName');
-              $this->subfield0or2($record, 'SeriesAddedPersonalName');
-            } else if ($record->field == '810') {
-              $this->createFacets($record, '810a_SeriesAddedCorporateName');
-              $this->subfield0or2($record, 'SeriesAddedCorporateName');
-            } else if ($record->field == '811') {
-              $this->createFacets($record, '811a_SeriesAddedMeetingName');
-              $this->subfield0or2($record, 'SeriesAddedMeetingName');
-            } else if ($record->field == '830') {
-              $this->createFacets($record, '830a_SeriesAddedUniformTitle');
-              $this->subfield0or2($record, 'SeriesAddedUniformTitle');
-            }
-          } elseif ($this->catalogue->getSchemaType() == 'PICA') {
-            $record->facet = $this->picaToSolr($record->field) . '_full_ss';
-            $record->facet2 = $record->facet;
-            $record->q = '*:*';
-            $definition = SchemaUtil::getDefinition($record->field);
-            $pica3 = ($definition != null && isset($definition->pica3) ? '=' . $definition->pica3 : '');
-            $record->withPica3 = $record->field . $pica3;
-          }
-
-          if (isset($record->facet2) && $record->facet2 != '') {
-            $record->facet2exists = in_array($record->facet2, $solrFields);
-          }
-
-          if (preg_match('/(^ |  +| $)/', $record->scheme)) {
-            $record->scheme = '"' . str_replace(' ', '&nbsp;', $record->scheme) . '"';
-          }
-
-          $record->ratio = $record->recordcount / $this->count;
-          $record->percent = $record->ratio * 100;
-
-          if ($record->scheme == 'undetectable')
-            $record->scheme = 'source not specified';
-
-          $key = $record->field;
-          if (!isset($records[$key]))
-            $records[$key] = [];
-          $records[$key][] = $record;
-        }
-      }
-      $smarty->assign('recordsByField', $records);
-
-      $this->readAuthoritiesSubfields($smarty);
-      $this->readElements($smarty);
-    } else {
+    if (!file_exists($byRecordsFile)) {
       error_log("By-records file ($byRecordsFile) doesn't exist!");
+      return;
+    }
+    $header = [];
+    $classificationRecords = [];
+    $in = fopen($byRecordsFile, "r");
+    while (($line = fgets($in)) != false) {
+      $values = str_getcsv($line);
+      if (empty($header)) {
+        $header = $values;
+        continue;
+      }
+      $classificationRecord = (object)array_combine($header, $values);
+      $classificationRecord->q = '*:*';
+
+      if ($this->catalogue->getSchemaType() == 'MARC21') {
+        $this->setMarc21FacetsAndQueries($classificationRecord);
+      } elseif ($this->catalogue->getSchemaType() == 'PICA') {
+        $this->setPicaFacets($classificationRecord);
+      } elseif ($this->catalogue->getSchemaType() == 'UNIMARC') {
+        $this->setUnimarcFacets($classificationRecord);
+      } else {
+        error_log('unhandled field in classification: ' . $classificationRecord->field);
+      }
+      if (isset($classificationRecord->facet2) && $classificationRecord->facet2 != '') {
+        $classificationRecord->facet2exists = in_array($classificationRecord->facet2, $solrFields);
+      }
+      if (preg_match('/(^ |  +| $)/', $classificationRecord->scheme)) {
+        $classificationRecord->scheme = '"' . str_replace(' ', '&nbsp;', $classificationRecord->scheme) . '"';
+      }
+      $classificationRecord->ratio = $classificationRecord->recordcount / $this->count;
+      $classificationRecord->percent = $classificationRecord->ratio * 100;
+
+      if ($classificationRecord->scheme == 'undetectable') {
+        $classificationRecord->scheme = 'source not specified';
+      }
+      $key = $classificationRecord->field;
+      if (!isset($classificationRecords[$key])) {
+        $classificationRecords[$key] = [];
+      }
+      $classificationRecords[$key][] = $classificationRecord;
+
+
+    }
+    $smarty->assign('recordsByField', $classificationRecords);
+
+    $this->readAuthoritiesSubfields($smarty);
+    $this->readElements($smarty);
+  }
+
+  private function setUnimarcFacets($classificationRecord) {
+
+    $originalField = $classificationRecord->field;
+    // If the field starts with 710, 711, or 712, then take into consideration the $ind1 indicator
+    if (preg_match('/^71[012]/', $classificationRecord->field)) {
+      // Ind1 is the last character of the field
+      $ind1 = substr($classificationRecord->field, -1);
+
+      // Take only first three characters of the field
+      $classificationRecord->field = substr($classificationRecord->field, 0, 3);
+
+      $this->createFacets($classificationRecord, $classificationRecord->field . 'a');
+
+      // Append the $ind1 indicator to the query
+      // This is slightly questionable, as the indicator could be set on some other instance of the field instead
+      // However, this issue should be addressed in the entire codebase
+      $indicatorQuery = $classificationRecord->field . 'ind1_' . $classificationRecord->field . '_ind1_ss';
+
+      $nameSpecifier = $ind1 == 0 ? 'Corporate name' : 'Meeting name';
+      $classificationRecord->q = sprintf('%s:%%22%s%%22', $indicatorQuery, $nameSpecifier);
+      $classificationRecord->field = $originalField;
+
+      return;
+    }
+
+    // Create facets for the UNIMARC schema in a sense that the facet is field with the subfield $a
+    // and the facet2 attribute is set only if there's a detected schema abbreviation
+    $this->createFacets($classificationRecord, $classificationRecord->field . 'a');
+
+    // Similarly to MARC21, but uniformly for all fields in UNIMARC, the source is specified only in the subfield $2
+    $subfield2 = $classificationRecord->field . '2_ss';
+    if ($classificationRecord->scheme == 'undetectable') {
+      $classificationRecord->q = sprintf('%s:* NOT %s:*', $classificationRecord->facet, $subfield2);
+    } else {
+      $classificationRecord->q = sprintf('%s:%%22%s%%22', $subfield2, urlencode($classificationRecord->abbreviation));
+    }
+    $classificationRecord->field = $originalField;
+  }
+
+  private function setPicaFacets($classificationRecord) {
+    $classificationRecord->facet = $this->picaToSolr($classificationRecord->field) . '_full_ss';
+    $classificationRecord->facet2 = $classificationRecord->facet;
+    $classificationRecord->q = '*:*';
+    $definition = SchemaUtil::getDefinition($classificationRecord->field);
+    $pica3 = ($definition != null && isset($definition->pica3) ? '=' . $definition->pica3 : '');
+    $classificationRecord->withPica3 = $classificationRecord->field . $pica3;
+  }
+
+  private function setMarc21FacetsAndQueries($classificationRecord) {
+    if ($classificationRecord->field == '100') {
+      $this->createFacets($classificationRecord, '100a_MainPersonalName_personalName');
+      $this->subfield0or2($classificationRecord, 'MainPersonalName');
+    } else if ($classificationRecord->field == '110') {
+      $this->createFacets($classificationRecord, '110a_MainCorporateName');
+      $this->subfield0or2($classificationRecord, 'MainCorporateName');
+    } else if ($classificationRecord->field == '111') {
+      $this->createFacets($classificationRecord, '111a_MainMeetingName');
+      $this->subfield0or2($classificationRecord, 'MainMeetingName');
+    } else if ($classificationRecord->field == '130') {
+      $this->createFacets($classificationRecord, '130a_MainUniformTitle');
+      $this->subfield0or2($classificationRecord, 'MainUniformTitle');
+    } else if ($classificationRecord->field == '700') {
+      $this->createFacets($classificationRecord, '700a_AddedPersonalName_personalName');
+      $this->subfield0or2($classificationRecord, 'AddedPersonalName');
+    } else if ($classificationRecord->field == '710') {
+      $this->createFacets($classificationRecord, '710a_AddedCorporateName');
+      $this->subfield0or2($classificationRecord, 'AddedCorporateName');
+    } else if ($classificationRecord->field == '711') {
+      $this->createFacets($classificationRecord, '711a_AddedMeetingName');
+      $this->subfield0or2($classificationRecord, 'AddedMeetingName');
+    } else if ($classificationRecord->field == '720') {
+      $this->createFacets($classificationRecord, '720a_UncontrolledName');
+      // $this->subfield0or2($record, '1000_MainPersonalName_authorityRecordControlNumber_organizationCode_ss', '1002_MainPersonalName_source_ss');
+    } else if ($classificationRecord->field == '730') {
+      $this->createFacets($classificationRecord, '730a_AddedUniformTitle');
+      $this->subfield0or2($classificationRecord, 'AddedUniformTitle');
+    } else if ($classificationRecord->field == '740') {
+      $this->createFacets($classificationRecord, '740a_AddedUncontrolledRelatedOrAnalyticalTitle');
+      // $this->subfield0or2($record, '1000_MainPersonalName_authorityRecordControlNumber_organizationCode_ss', '1002_MainPersonalName_source_ss');
+    } else if ($classificationRecord->field == '751') {
+      $this->createFacets($classificationRecord, '751a_AddedGeographicName');
+      // $this->subfield0or2($record, '1000_MainPersonalName_authorityRecordControlNumber_organizationCode_ss', '1002_MainPersonalName_source_ss');
+    } else if ($classificationRecord->field == '752') {
+      $this->createFacets($classificationRecord, '752a_HierarchicalGeographic_country');
+      $this->subfield0or2($classificationRecord, 'HierarchicalGeographic');
+    } else if ($classificationRecord->field == '753') {
+      $this->createFacets($classificationRecord, '753a_SystemRequirement_machineModel');
+      // $this->subfield0or2($record, '1000_MainPersonalName_authorityRecordControlNumber_organizationCode_ss', '1002_MainPersonalName_source_ss');
+    } else if ($classificationRecord->field == '754') {
+      $this->createFacets($classificationRecord, '754a_TaxonomicIdentification_name');
+      $this->subfield0or2($classificationRecord, 'TaxonomicIdentification');
+    } else if ($classificationRecord->field == '800') {
+      $this->createFacets($classificationRecord, '800a_SeriesAddedPersonalName_personalName');
+      $this->subfield0or2($classificationRecord, 'SeriesAddedPersonalName');
+    } else if ($classificationRecord->field == '810') {
+      $this->createFacets($classificationRecord, '810a_SeriesAddedCorporateName');
+      $this->subfield0or2($classificationRecord, 'SeriesAddedCorporateName');
+    } else if ($classificationRecord->field == '811') {
+      $this->createFacets($classificationRecord, '811a_SeriesAddedMeetingName');
+      $this->subfield0or2($classificationRecord, 'SeriesAddedMeetingName');
+    } else if ($classificationRecord->field == '830') {
+      $this->createFacets($classificationRecord, '830a_SeriesAddedUniformTitle');
+      $this->subfield0or2($classificationRecord, 'SeriesAddedUniformTitle');
     }
   }
 
-  /**
+    /**
    * @param Smarty $smarty
    * @return object
    */
@@ -326,6 +399,55 @@ class Authorities extends AddedEntry {
           ]
         ]
       ];
+    } elseif ($this->catalogue->getSchemaType() == 'UNIMARC') {
+      $categories = [
+        'Personal names' => (object)[
+          'icon' => 'fa-user',
+          'fields' => [
+            '700' => 'PERSONAL NAME – PRIMARY RESPONSIBILITY',
+            '701' => 'PERSONAL NAME – ALTERNATIVE RESPONSIBILITY',
+            '702' => 'PERSONAL NAME – SECONDARY RESPONSIBILITY',
+          ]
+        ],
+        'Corporate names' => (object)[
+          'icon' => 'fa-building',
+          'fields' => [
+            '710$ind1=0' => 'CORPORATE BODY NAME – PRIMARY RESPONSIBILITY',
+            '711$ind1=0' => 'CORPORATE BODY NAME – ALTERNATIVE RESPONSIBILITY',
+            '712$ind1=0' => 'CORPORATE BODY NAME – SECONDARY RESPONSIBILITY',
+          ]
+        ],
+        'Meeting names' => (object)[
+          'icon' => 'fa-calendar',
+          'fields' => [
+            '710$ind1=1' => 'MEETING BODY NAME – PRIMARY RESPONSIBILITY',
+            '711$ind1=1' => 'MEETING BODY NAME – ALTERNATIVE RESPONSIBILITY',
+            '712$ind1=1' => 'MEETING BODY NAME – SECONDARY RESPONSIBILITY',
+          ]
+        ],
+        'Geographic names' => (object)[
+          'icon' => 'fa-map',
+          'fields' => [
+            '620' => 'PLACE AND DATE OF PUBLICATION, PERFORMANCE, ETC.',
+          ]
+        ],
+        'Titles' => (object)[
+          'icon' => 'fa-book',
+          'fields' => [
+            '501' => 'CONVENTIONAL PREFERRED TITLE',
+            '506' => 'PREFERRED ACCESS POINT – IDENTIFICATION OF A WORK',
+            '507' => 'PREFERRED ACCESS POINT – IDENTIFICATION OF AN EXPRESSION',
+            '576' => 'NAME / ACCESS POINT– IDENTIFICATION OF A WORK',
+            '577' => 'NAME / ACCESS POINT– IDENTIFICATION OF AN EXPRESSION',
+          ]
+        ],
+        'Other' => (object)[
+          'icon' => 'fa-archive',
+          'fields' => [
+            '730' => 'NAME – ENTITY RESPONSIBLE',
+          ]
+        ]
+      ];
     }
 
     foreach ($categories as $name => $obj) {
@@ -335,11 +457,12 @@ class Authorities extends AddedEntry {
       $obj->percent = $obj->ratio * 100;
       foreach ($obj->fields as $key => $value) {
         $obj->fields[$key] = (object)['name' => $value];
-        if ($this->catalogue->getSchemaType() == 'PICA') {
-          $definition = SchemaUtil::getDefinition($key);
-          if ($definition != null && isset($definition->pica3)) {
-            $obj->fields[$key]->pica3 = $key . '=' . $definition->pica3;
-          }
+        if ($this->catalogue->getSchemaType() != 'PICA') {
+          continue;
+        }
+        $definition = SchemaUtil::getDefinition($key);
+        if ($definition != null && isset($definition->pica3)) {
+          $obj->fields[$key]->pica3 = $key . '=' . $definition->pica3;
         }
       }
     }
@@ -348,13 +471,14 @@ class Authorities extends AddedEntry {
 
   private function readFrequencyExamples(Smarty &$smarty) {
     $file = $this->getFilePath('authorities-frequency-examples.csv');
-    if (file_exists($file)) {
-      $frequencyExamples = readCsv($file);
-      $examples = [];
-      foreach ($frequencyExamples as $example) {
-        $examples[$example->count] = $example->id;
-      }
-      $smarty->assign('frequencyExamples', $examples);
+    if (!file_exists($file)) {
+      return;
     }
+    $frequencyExamples = readCsv($file);
+    $examples = [];
+    foreach ($frequencyExamples as $example) {
+      $examples[$example->count] = $example->id;
+    }
+    $smarty->assign('frequencyExamples', $examples);
   }
 }

--- a/classes/Classifications.php
+++ b/classes/Classifications.php
@@ -1,5 +1,7 @@
 <?php
 
+use Schema\Pica\PicaSchemaManager;
+
 class Classifications extends AddedEntry {
 
   protected $frequencyExamples;
@@ -18,49 +20,62 @@ class Classifications extends AddedEntry {
   }
 
   private function loadByRecords(Smarty &$smarty) {
-    $records = Classifications::readByRecords($this->getFilePath('classifications-by-records.csv'), $this->count);
+    $classificationRecords = Classifications::readByRecords($this->getFilePath('classifications-by-records.csv'), $this->count);
 
     $smarty->assign('count', $this->count);
-    $smarty->assign('withClassification', $records->withClassification);
-    $smarty->assign('withoutClassification', $records->withoutClassification);
+    $smarty->assign('withClassification', $classificationRecords->withClassification);
+
+    $smarty->assign('withoutClassification', $classificationRecords->withoutClassification);
   }
 
   public static function readByRecords($filepath, $total) {
-    $records = [];
-    if (file_exists($filepath)) {
-      $header = [];
-      $in = fopen($filepath, "r");
-      while (($line = fgets($in)) != false) {
-        $values = str_getcsv($line);
-        if (empty($header)) {
-          $header = $values;
-        } else {
-          $record = (object)array_combine($header, $values);
-          $record->percent = $record->count / $total;
-          if ($record->{'records-with-classification'} === 'true') {
-            $records["withClassification"] = $record;
-          } else {
-            $records["withoutClassification"] = $record;
-          }
-        }
-      }
-      return (object)$records;
+    $classificationRecords = [];
+    if (!file_exists($filepath)) {
+      return (object)$classificationRecords;
     }
+
+    $header = [];
+    $in = fopen($filepath, "r");
+    while (($line = fgets($in)) != false) {
+      $values = str_getcsv($line);
+      if (empty($header)) {
+        $header = $values;
+        continue;
+      }
+
+      $classificationRecord = (object)array_combine($header, $values);
+      $classificationRecord->percent = $classificationRecord->count / $total;
+      if ($classificationRecord->{'records-with-classification'} === 'true') {
+        $classificationRecords["withClassification"] = $classificationRecord;
+      } else {
+        $classificationRecords["withoutClassification"] = $classificationRecord;
+      }
+
+    }
+    return (object)$classificationRecords;
   }
 
   private function readByField(Smarty &$smarty) {
     $solrFields = $this->solr()->getSolrFields(); // $this->id
     SchemaUtil::initializeSchema($this->catalogue->getSchemaType());
-
+    // Define the fields variable
     if ($this->catalogue->getSchemaType() == 'MARC21') {
       $fields = $this->getMarc21PredefinedSubjectFields();
     } elseif ($this->catalogue->getSchemaType() == 'PICA') {
-      $schema = new \Schema\Pica\PicaSchemaManager();
       $fields = $this->readPicaSubjectFieldsFromFile();
       if (empty($fields)) {
         $fields = $this->getPicaPredefinedSubjectFields();
       }
       $picaFields = array_keys($fields);
+    } elseif ($this->catalogue->getSchemaType() == 'UNIMARC') {
+      $fieldList = ["600", "601", "602", "604", "605", "606",
+        "607", "608", "610", "615", "616", "617", "620", "621", "623", "626", "631", "632", "660", "661", "670", "675",
+        "676", "680", "686"];
+
+      // Get the field labels from the UNIMARC schema
+      foreach ($fieldList as $field) {
+        $fields[$field] = SchemaUtil::getDefinition($field)->label;
+      }
     }
 
     $solrFieldMap = $this->getSolrFieldMap();
@@ -69,45 +84,50 @@ class Classifications extends AddedEntry {
     if (!file_exists($byRecordsFile)) {
       $byRecordsFile = $this->getFilePath('classifications-by-field.csv');
     }
-    if (file_exists($byRecordsFile)) {
-      error_log('classification file: ' . $byRecordsFile);
-      $header = [];
-      $records = [];
-      $in = fopen($byRecordsFile, "r");
-      while (($line = fgets($in)) != false) {
-        $values = str_getcsv($line);
-        if (empty($header)) {
-          $header = $values;
-        } else {
-          $record = (object)array_combine($header, $values);
-          if ($this->catalogue->getSchemaType() == 'MARC21') {
-            $record = $this->createFacetForMarc21($record, $solrFieldMap);
-          } else if ($this->catalogue->getSchemaType() == 'PICA') {
-            $this->createFacetForPica($record, $picaFields);
-          }
-
-          if (isset($record->facet2) && $record->facet2 != '') {
-            $record->facet2exists = in_array($record->facet2, $solrFields);
-            if (!$record->facet2exists)
-              error_log($record->facet2 . ' is not existing');
-          }
-
-          if (preg_match('/(^ |  +| $)/', $record->scheme))
-            $record->scheme = '"' . str_replace(' ', '&nbsp;', $record->scheme) . '"';
-
-          $record->ratio = $record->recordcount / $this->count;
-          $record->percent = $record->ratio * 100;
-
-          $records[] = $record;
+    if (!file_exists($byRecordsFile)) {
+      return;
+    }
+    
+    error_log('classification file: ' . $byRecordsFile);
+    $header = [];
+    $classificationRecords = [];
+    $in = fopen($byRecordsFile, "r");
+    while (($line = fgets($in)) != false) {
+      $values = str_getcsv($line);
+      if (empty($header)) {
+        $header = $values;
+        continue;
+      }
+      $classificationRecord = (object)array_combine($header, $values);
+      if ($this->catalogue->getSchemaType() == 'MARC21') {
+        $this->createFacetForMarc21($classificationRecord, $solrFieldMap);
+      } elseif ($this->catalogue->getSchemaType() == 'PICA') {
+        $this->createFacetForPica($classificationRecord, $picaFields);
+      } elseif ($this->catalogue->getSchemaType() == 'UNIMARC') {
+        $this->setUnimarcFacets($classificationRecord);
+      } else {
+        error_log('unhandled field in classification: ' . $classificationRecord->field);
+      }
+      if (isset($classificationRecord->facet2) && $classificationRecord->facet2 != '') {
+        $classificationRecord->facet2exists = in_array($classificationRecord->facet2, $solrFields);
+        if (!$classificationRecord->facet2exists) {
+          error_log($classificationRecord->facet2 . ' is not existing');
         }
       }
+      if (preg_match('/(^ |  +| $)/', $classificationRecord->scheme)) {
+        $classificationRecord->scheme = '"' . str_replace(' ', '&nbsp;', $classificationRecord->scheme) . '"';
+      }
+      $classificationRecord->ratio = $classificationRecord->recordcount / $this->count;
+      $classificationRecord->percent = $classificationRecord->ratio * 100;
 
-      $smarty->assign('records', $records);
-      $smarty->assign('fields', $fields);
-
-      $this->readClassificationSubfields($smarty);
-      $this->readElements($smarty);
+      $classificationRecords[] = $classificationRecord;
     }
+
+    $smarty->assign('records', $classificationRecords);
+    $smarty->assign('fields', $fields);
+
+    $this->readClassificationSubfields($smarty);
+    $this->readElements($smarty);
   }
 
   private function readFrequencyExamples(Smarty &$smarty) {
@@ -174,6 +194,28 @@ class Classifications extends AddedEntry {
     return $fields;
   }
 
+  private function setUnimarcFacets($classificationRecord) {
+    // Fields 675, 676, and 677 have no specific queries
+    if (in_array($classificationRecord->field, ['675', '676', '677'])) {
+      $classificationRecord->facet = $classificationRecord->field . 'a_ss';
+      $classificationRecord->q = '*:*';
+      return;
+    }
+
+    // Create facets for the UNIMARC schema in a sense that the facet is field with the subfield $a
+    // and the facet2 attribute is set only if there's a detected schema abbreviation
+    $this->createFacets($classificationRecord, $classificationRecord->field . 'a');
+
+    // Similarly to MARC21, but uniformly for all fields in UNIMARC, the source is specified only in the subfield $2
+    $subfield2 = $classificationRecord->field . '2_ss';
+    if ($classificationRecord->scheme == 'undetectable') {
+      $classificationRecord->q = sprintf('%s:* NOT %s:*', $classificationRecord->facet, $subfield2);
+    } else {
+      $classificationRecord->q = sprintf('%s:%%22%s%%22', $subfield2, urlencode($classificationRecord->abbreviation));
+    }
+  }
+
+
   /**
    * @return string[]
    */
@@ -210,98 +252,97 @@ class Classifications extends AddedEntry {
   }
 
   /**
-   * @param object $record
+   * @param object $classificationRecord
    * @param array $solrFieldMap
    * @return object
    */
-  protected function createFacetForMarc21(object $record, array $solrFieldMap): object
+  protected function createFacetForMarc21(object $classificationRecord, array $solrFieldMap): object
   {
-    if ($record->field == '052') {
-      $this->createFacets($record, '052a_GeographicClassification');
-      $this->ind1Orsubfield2($record, '052ind1_GeographicClassification_codeSource_ss', '0522_GeographicClassification_source_ss');
-    } else if ($record->field == '055') {
-      $this->createFacets($record, '055a_ClassificationLcc');
-      $this->ind2Orsubfield2($record, '055ind2_ClassificationLcc_type_ss', '0552_ClassificationLcc_source_ss');
-    } else if ($record->field == '072') {
-      $this->createFacets($record, '072a_SubjectCategoryCode');
-      $this->ind2Orsubfield2($record, '072ind2_SubjectCategoryCode_codeSource_ss', '0722_SubjectCategoryCode_source_ss');
-    } else if ($record->field == '080') {
-      $record->facet = $solrFieldMap[$record->field . str_replace('$', '', $record->location)]; // '080a_Udc_ss';
-      $record->q = '*:*';
-    } else if ($record->field == '082') {
-      $record->facet = $solrFieldMap[$record->field . str_replace('$', '', $record->location)]; // '082a_ClassificationDdc_ss';
-      $record->q = '*:*';
-    } else if ($record->field == '083') {
-      $record->facet = $solrFieldMap[$record->field . str_replace('$', '', $record->location)]; // '083a_ClassificationAdditionalDdc_ss';
-      $record->q = '*:*';
-    } else if ($record->field == '084') {
-      $this->createFacets($record, '084a_Classification_classificationPortion');
-      $record->q = urlencode(sprintf('%s:"%s"', '0842_Classification_source_ss', $record->scheme));
-    } else if ($record->field == '085') {
-      $record->facet = $solrFieldMap[$record->field . str_replace('$', '', $record->location)]; // '085b_SynthesizedClassificationNumber_baseNumber_ss';
-      $record->q = '*:*';
-    } else if ($record->field == '086') {
-      $this->createFacets($record, '086a_GovernmentDocumentClassification');
-      $this->ind1Orsubfield2($record, '086ind1_GovernmentDocumentClassification_numberSource_ss', '0862_GovernmentDocumentClassification_source_ss');
-    } else if ($record->field == '600') {
-      $this->createFacets($record, '600a_PersonalNameSubject_personalName');
-      $this->ind2Orsubfield2($record, '600ind2_PersonalNameSubject_thesaurus_ss', '6002_PersonalNameSubject_source_ss');
-    } else if ($record->field == '610') {
-      $this->createFacets($record, '610a_CorporateNameSubject');
-      $this->ind2Orsubfield2($record, '610ind2_CorporateNameSubject_thesaurus_ss', '6102_CorporateNameSubject_source_ss');
-    } else if ($record->field == '611') {
-      $this->createFacets($record, '611a_SubjectAddedMeetingName');
-      $this->ind2Orsubfield2($record, '611ind2_SubjectAddedMeetingName_thesaurus_ss', '6112_SubjectAddedMeetingName_source_ss');
-    } else if ($record->field == '630') {
-      $this->createFacets($record, '630a_SubjectAddedUniformTitle');
-      $this->ind2Orsubfield2($record, '630ind2_SubjectAddedUniformTitle_thesaurus_ss', '6302_SubjectAddedUniformTitle_source_ss');
+    if ($classificationRecord->field == '052') {
+      $this->createFacets($classificationRecord, '052a_GeographicClassification');
+      $this->ind1Orsubfield2($classificationRecord, '052ind1_GeographicClassification_codeSource_ss', '0522_GeographicClassification_source_ss');
+    } elseif ($classificationRecord->field == '055') {
+      $this->createFacets($classificationRecord, '055a_ClassificationLcc');
+      $this->ind2Orsubfield2($classificationRecord, '055ind2_ClassificationLcc_type_ss', '0552_ClassificationLcc_source_ss');
+    } elseif ($classificationRecord->field == '072') {
+      $this->createFacets($classificationRecord, '072a_SubjectCategoryCode');
+      $this->ind2Orsubfield2($classificationRecord, '072ind2_SubjectCategoryCode_codeSource_ss', '0722_SubjectCategoryCode_source_ss');
+    } elseif ($classificationRecord->field == '080') {
+      $classificationRecord->facet = $solrFieldMap[$classificationRecord->field . str_replace('$', '', $classificationRecord->location)]; // '080a_Udc_ss';
+      $classificationRecord->q = '*:*';
+    } elseif ($classificationRecord->field == '082') {
+      $classificationRecord->facet = $solrFieldMap[$classificationRecord->field . str_replace('$', '', $classificationRecord->location)]; // '082a_ClassificationDdc_ss';
+      $classificationRecord->q = '*:*';
+    } elseif ($classificationRecord->field == '083') {
+      $classificationRecord->facet = $solrFieldMap[$classificationRecord->field . str_replace('$', '', $classificationRecord->location)]; // '083a_ClassificationAdditionalDdc_ss';
+      $classificationRecord->q = '*:*';
+    } elseif ($classificationRecord->field == '084') {
+      $this->createFacets($classificationRecord, '084a_Classification_classificationPortion');
+      $classificationRecord->q = urlencode(sprintf('%s:"%s"', '0842_Classification_source_ss', $classificationRecord->scheme));
+    } elseif ($classificationRecord->field == '085') {
+      $classificationRecord->facet = $solrFieldMap[$classificationRecord->field . str_replace('$', '', $classificationRecord->location)]; // '085b_SynthesizedClassificationNumber_baseNumber_ss';
+      $classificationRecord->q = '*:*';
+    } elseif ($classificationRecord->field == '086') {
+      $this->createFacets($classificationRecord, '086a_GovernmentDocumentClassification');
+      $this->ind1Orsubfield2($classificationRecord, '086ind1_GovernmentDocumentClassification_numberSource_ss', '0862_GovernmentDocumentClassification_source_ss');
+    } elseif ($classificationRecord->field == '600') {
+      $this->createFacets($classificationRecord, '600a_PersonalNameSubject_personalName');
+      $this->ind2Orsubfield2($classificationRecord, '600ind2_PersonalNameSubject_thesaurus_ss', '6002_PersonalNameSubject_source_ss');
+    } elseif ($classificationRecord->field == '610') {
+      $this->createFacets($classificationRecord, '610a_CorporateNameSubject');
+      $this->ind2Orsubfield2($classificationRecord, '610ind2_CorporateNameSubject_thesaurus_ss', '6102_CorporateNameSubject_source_ss');
+    } elseif ($classificationRecord->field == '611') {
+      $this->createFacets($classificationRecord, '611a_SubjectAddedMeetingName');
+      $this->ind2Orsubfield2($classificationRecord, '611ind2_SubjectAddedMeetingName_thesaurus_ss', '6112_SubjectAddedMeetingName_source_ss');
+    } elseif ($classificationRecord->field == '630') {
+      $this->createFacets($classificationRecord, '630a_SubjectAddedUniformTitle');
+      $this->ind2Orsubfield2($classificationRecord, '630ind2_SubjectAddedUniformTitle_thesaurus_ss', '6302_SubjectAddedUniformTitle_source_ss');
       // TODO: 647
-    } else if ($record->field == '648') {
-      $this->createFacets($record, '648a_ChronologicalSubject');
-      $this->ind2Orsubfield2($record, '648ind2_ChronologicalSubject_thesaurus_ss', '6482_ChronologicalSubject_source_ss');
-    } else if ($record->field == '650') {
-      $this->createFacets($record, '650a_Topic_topicalTerm');
-      $this->ind2Orsubfield2($record, '650ind2_Topic_thesaurus_ss', '6502_Topic_sourceOfHeading_ss');
-    } else if ($record->field == '651') {
-      $this->createFacets($record, '651a_Geographic');
-      $this->ind2Orsubfield2($record, '651ind2_Geographic_thesaurus_ss', '6512_Geographic_source_ss');
-    } else if ($record->field == '653') {
-      $this->createFacets($record, '653a_UncontrolledIndexTerm');
-      $record->q = urlencode(sprintf('653ind2_UncontrolledIndexTerm_type_ss:"%s"', $record->scheme));
-    } else if ($record->field == '655') {
-      $this->createFacets($record, '655a_GenreForm');
-      $this->ind2Orsubfield2($record, '655ind2_GenreForm_thesaurus_ss', '6552_GenreForm_source_ss');
-    } else if ($record->field == '658') {
-      $this->createFacets($record, '658a_CurriculumObjective_main');
-      $this->subfield0or2($record, 'CurriculumObjective');
-    } else if ($record->field == '662') {
-      $this->createFacets($record, '662a_HierarchicalGeographic_country');
-      $this->subfield0or2($record, 'HierarchicalGeographic');
-    } else if ($record->field == '852') {
-      $this->createFacets($record, '852a_Location_location');
-      $this->ind1Orsubfield2($record, '852ind1_852_shelvingScheme_ss', '852__852___ss');
+    } elseif ($classificationRecord->field == '648') {
+      $this->createFacets($classificationRecord, '648a_ChronologicalSubject');
+      $this->ind2Orsubfield2($classificationRecord, '648ind2_ChronologicalSubject_thesaurus_ss', '6482_ChronologicalSubject_source_ss');
+    } elseif ($classificationRecord->field == '650') {
+      $this->createFacets($classificationRecord, '650a_Topic_topicalTerm');
+      $this->ind2Orsubfield2($classificationRecord, '650ind2_Topic_thesaurus_ss', '6502_Topic_sourceOfHeading_ss');
+    } elseif ($classificationRecord->field == '651') {
+      $this->createFacets($classificationRecord, '651a_Geographic');
+      $this->ind2Orsubfield2($classificationRecord, '651ind2_Geographic_thesaurus_ss', '6512_Geographic_source_ss');
+    } elseif ($classificationRecord->field == '653') {
+      $this->createFacets($classificationRecord, '653a_UncontrolledIndexTerm');
+      $classificationRecord->q = urlencode(sprintf('653ind2_UncontrolledIndexTerm_type_ss:"%s"', $classificationRecord->scheme));
+    } elseif ($classificationRecord->field == '655') {
+      $this->createFacets($classificationRecord, '655a_GenreForm');
+      $this->ind2Orsubfield2($classificationRecord, '655ind2_GenreForm_thesaurus_ss', '6552_GenreForm_source_ss');
+    } elseif ($classificationRecord->field == '658') {
+      $this->createFacets($classificationRecord, '658a_CurriculumObjective_main');
+      $this->subfield0or2($classificationRecord, 'CurriculumObjective');
+    } elseif ($classificationRecord->field == '662') {
+      $this->createFacets($classificationRecord, '662a_HierarchicalGeographic_country');
+      $this->subfield0or2($classificationRecord, 'HierarchicalGeographic');
+    } elseif ($classificationRecord->field == '852') {
+      $this->createFacets($classificationRecord, '852a_Location_location');
+      $this->ind1Orsubfield2($classificationRecord, '852ind1_852_shelvingScheme_ss', '852__852___ss');
     } else {
-      error_log('unhandled field in classification: ' . $record->field);
+      error_log('unhandled field in classification: ' . $classificationRecord->field);
     }
-    return $record;
+    return $classificationRecord;
   }
 
   /**
-   * @param object $record
+   * @param object $classificationRecord
    * @param array $picaFields
    * @return void
    */
-  protected function createFacetForPica(object $record, array $picaFields): void
+  protected function createFacetForPica(object $classificationRecord, array $picaFields): void
   {
-    if (in_array($record->field, $picaFields)) {
-      $record->facet = $this->picaToSolr($record->field) . '_full_ss';
-      $record->facet2 = $record->facet; // . '_full_ss';
-
-      $definition = SchemaUtil::getDefinition($record->field);
-      $pica3 = ($definition != null && isset($definition->pica3) ? '=' . $definition->pica3 : '');
-      $record->withPica3 = $record->field . $pica3;
-    } else {
-      error_log('unhandled field in classification: ' . $record->field);
+    if (!in_array($classificationRecord->field, $picaFields)) {
+      error_log('unhandled field in classification: ' . $classificationRecord->field);
+      return;
     }
+    $classificationRecord->facet = $this->picaToSolr($classificationRecord->field) . '_full_ss';
+    $classificationRecord->facet2 = $classificationRecord->facet; // . '_full_ss';
+    $definition = SchemaUtil::getDefinition($classificationRecord->field);
+    $pica3 = ($definition != null && isset($definition->pica3) ? '=' . $definition->pica3 : '');
+    $classificationRecord->withPica3 = $classificationRecord->field . $pica3;
   }
 }

--- a/classes/FunctionalAnalysisHistogram.php
+++ b/classes/FunctionalAnalysisHistogram.php
@@ -24,53 +24,53 @@ class FunctionalAnalysisHistogram extends BaseTab {
 
   private function read($filename) {
     $elementsFile = $this->getFilePath($filename . '.csv');
-    if (file_exists($elementsFile)) {
-      $lineNumber = 0;
-      $header = [];
-      $in = fopen($elementsFile, "r");
-      $groupedCsv = [];
-      while (($line = fgets($in)) != false) {
-        $lineNumber++;
-        $values = str_getcsv($line);
-        if ($lineNumber == 1) {
-          $header = $values;
-          $currentFunction = '';
+    if (!file_exists($elementsFile)) {
+      return;
+    }
+    $lineNumber = 0;
+    $header = [];
+    $in = fopen($elementsFile, "r");
+    $groupedCsv = [];
+    while (($line = fgets($in)) != false) {
+      $lineNumber++;
+      $values = str_getcsv($line);
+      if ($lineNumber == 1) {
+        $header = $values;
+        $currentFunction = '';
+        $function_report = [];
+        if ($this->selectedFunction != '')
+          $groupedCsv[] = ['count', 'frequency'];
+        else
+          $groupedCsv[] = ['frbrfunction', 'score', 'count'];
+      } else {
+        if (count($header) != count($values)) {
+          error_log('line #' . $lineNumber . ': ' . count($header) . ' vs ' . count($values));
+        }
+        $record = (object)array_combine($header, $values);
+        if ($this->selectedFunction != '' && $this->selectedFunction != $record->frbrfunction)
+          continue;
+
+        if ($record->frbrfunction != $currentFunction) {
+          if ($currentFunction != '') {
+            $this->addFunctionReport($currentFunction, $function_report, $groupedCsv);
+          }
           $function_report = [];
-          if ($this->selectedFunction != '')
-            $groupedCsv[] = ['count', 'frequency'];
-          else
-            $groupedCsv[] = ['frbrfunction', 'score', 'count'];
+          $currentFunction = $record->frbrfunction;
+        }
+
+        $rounded = $record->functioncount;
+        if (!isset($function_report[$rounded])) {
+          $function_report[$rounded] = $record->count;
         } else {
-          if (count($header) != count($values)) {
-            error_log('line #' . $lineNumber . ': ' . count($header) . ' vs ' . count($values));
-          }
-          $record = (object)array_combine($header, $values);
-          if ($this->selectedFunction != '' && $this->selectedFunction != $record->frbrfunction)
-            continue;
-
-          if ($record->frbrfunction != $currentFunction) {
-            if ($currentFunction != '') {
-              $this->addFunctionReport($currentFunction, $function_report, $groupedCsv);
-            }
-            $function_report = [];
-            $currentFunction = $record->frbrfunction;
-          }
-
-          $rounded = round($record->score * 100);
-          $rounded = $record->functioncount;
-          if (!isset($function_report[$rounded])) {
-            $function_report[$rounded] = $record->count;
-          } else {
-            $function_report[$rounded] += $record->count;
-          }
+          $function_report[$rounded] += $record->count;
         }
       }
-      $this->addFunctionReport($currentFunction, $function_report, $groupedCsv);
-      fclose($in);
-
-      header("Content-type: text/csv");
-      echo $this->formatAsCsv($groupedCsv);
     }
+    $this->addFunctionReport($currentFunction, $function_report, $groupedCsv);
+    fclose($in);
+
+    header("Content-type: text/csv");
+    echo $this->formatAsCsv($groupedCsv);
   }
 
   private function addFunctionReport($current_function, $function_report, &$grouped_csv) {

--- a/classes/Functions.php
+++ b/classes/Functions.php
@@ -80,28 +80,32 @@ class Functions extends BaseTab {
     $elements = $this->readMarcElements();
 
     $file = $this->getFilePath('functional-analysis-mapping.csv');
-    if (file_exists($file)) {
-      $records = readCsv($file);
-      foreach ($records as $record) {
-        if ($record->frbrfunction == $this->function) {
-          $smarty->assign('fieldCount', $record->count);
-          $rawFields = explode(';', $record->fields);
-          $fields = [];
-          foreach ($rawFields as $field) {
-            $item = (object)['name' => $field];
-            if (preg_match('/ind[12]$/', $field)) {
-              $tag = substr($field, 0, 3);
-              if (isset($elements[$tag]))
-                $item->link = $tag;
-            } else {
-              if (isset($elements[$field]))
-                $item->link = $field;
-            }
-            $fields[] = $item;
-          }
-          $smarty->assign('fields', $fields);
-        }
+    if (!file_exists($file)) {
+      return;
+    }
+
+    $records = readCsv($file);
+    foreach ($records as $record) {
+      if ($record->frbrfunction != $this->function) {
+        continue;
       }
+
+      $smarty->assign('fieldCount', $record->count);
+      $rawFields = explode(';', $record->fields);
+      $fields = [];
+      foreach ($rawFields as $field) {
+        $item = (object)['name' => $field];
+        if (preg_match('/ind[12]$/', $field)) {
+          $tag = substr($field, 0, 3);
+          if (isset($elements[$tag])) {
+            $item->link = $tag;
+          }
+        } else if (isset($elements[$field])) {
+            $item->link = $field;
+        }
+        $fields[] = $item;
+      }
+      $smarty->assign('fields', $fields);
     }
   }
 

--- a/classes/Schema/SchemaManager.php
+++ b/classes/Schema/SchemaManager.php
@@ -14,8 +14,13 @@ abstract class SchemaManager {
   protected function extractFields(): void {
     $this->fields = json_decode(file_get_contents($this->schemaFile))->fields;
     foreach ($this->fields as $id => $field) {
-      if ($this->supportRange)
+      if ($this->supportRange) {
         $this->createRange($field);
+      }
+
+      if (!isset($field->tag)) {
+        continue;
+      }
 
       if (!isset($this->tagIndex[$field->tag])) {
         $this->tagIndex[$field->tag] = [];

--- a/templates/common/html-head.tpl
+++ b/templates/common/html-head.tpl
@@ -7,15 +7,24 @@
   <title>QA catalogue for analysing library data</title>
   <link rel="shortcut icon" type="image/x-icon" href="./favicon.ico">
   <!-- Bootstrap CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+  <!-- link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous" -->
+  <link rel="stylesheet" href="./styles/external-libs/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
 
-  <script src="https://code.jquery.com/jquery-3.2.1.min.js" integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4=" crossorigin="anonymous"></script>
-  <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.12.9/dist/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
-  <script src="https://use.fontawesome.com/feff23b961.js"></script>
-  <script src="https://kit.fontawesome.com/2f4e00a49c.js" crossorigin="anonymous"></script>
-  <script src="https://code.jquery.com/jquery-3.2.1.js" integrity="sha256-DZAnKJ/6XZ9si04Hgrsxu/8s717jcIzLy3oi35EouyE=" crossorigin="anonymous"></script>
+  <!-- script src="https://code.jquery.com/jquery-3.2.1.min.js" integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4=" crossorigin="anonymous"></script -->
+  <script src="./js/external-libs/jquery-3.2.1.min.js" integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4=" crossorigin="anonymous"></script>
+  <!-- script src="https://code.jquery.com/ui/1.13.2/jquery-ui.js"></script -->
+  <script src="./js/external-libs/jquery-ui.js"></script>
+  <!-- script src="https://cdn.jsdelivr.net/npm/popper.js@1.12.9/dist/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script -->
+  <script src="./js/external-libs/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+  <!-- script src="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script -->
+  <script src="./js/external-libs/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+  <!-- fontawesome
+  <script src="//use.fontawesome.com/feff23b961.js"></script>
+  <script src="js/feff23b961.js"></script>
+   -->
+  <!-- script src="https://kit.fontawesome.com/2f4e00a49c.js" crossorigin="anonymous"></script -->
+  <script src="./js/external-libs/2f4e00a49c.js" crossorigin="anonymous"></script>
+  <!-- script src="//code.jquery.com/jquery-3.2.1.js" integrity="sha256-DZAnKJ/6XZ9si04Hgrsxu/8s717jcIzLy3oi35EouyE=" crossorigin="anonymous"></script -->
   <link rel="stylesheet" href="styles/metadata-qa.css">
   <script type="text/javascript">
     var marcBaseUrl = 'https://www.loc.gov/marc/bibliographic/';
@@ -23,7 +32,8 @@
       return marcBaseUrl + link;
     }
   </script>
-  <script src="https://d3js.org/d3.v5.min.js"></script>
+  <!-- script src="https://d3js.org/d3.v5.min.js"></script -->
+  <script src="./js/external-libs/d3.v5.min.js"></script>
 </head>
 <body>
 {if isset($error)}

--- a/templates/common/html-head.tpl
+++ b/templates/common/html-head.tpl
@@ -7,24 +7,15 @@
   <title>QA catalogue for analysing library data</title>
   <link rel="shortcut icon" type="image/x-icon" href="./favicon.ico">
   <!-- Bootstrap CSS -->
-  <!-- link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous" -->
-  <link rel="stylesheet" href="./styles/external-libs/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
 
-  <!-- script src="https://code.jquery.com/jquery-3.2.1.min.js" integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4=" crossorigin="anonymous"></script -->
-  <script src="./js/external-libs/jquery-3.2.1.min.js" integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4=" crossorigin="anonymous"></script>
-  <!-- script src="https://code.jquery.com/ui/1.13.2/jquery-ui.js"></script -->
-  <script src="./js/external-libs/jquery-ui.js"></script>
-  <!-- script src="https://cdn.jsdelivr.net/npm/popper.js@1.12.9/dist/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script -->
-  <script src="./js/external-libs/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
-  <!-- script src="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script -->
-  <script src="./js/external-libs/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
-  <!-- fontawesome
-  <script src="//use.fontawesome.com/feff23b961.js"></script>
-  <script src="js/feff23b961.js"></script>
-   -->
-  <!-- script src="https://kit.fontawesome.com/2f4e00a49c.js" crossorigin="anonymous"></script -->
-  <script src="./js/external-libs/2f4e00a49c.js" crossorigin="anonymous"></script>
-  <!-- script src="//code.jquery.com/jquery-3.2.1.js" integrity="sha256-DZAnKJ/6XZ9si04Hgrsxu/8s717jcIzLy3oi35EouyE=" crossorigin="anonymous"></script -->
+  <script src="https://code.jquery.com/jquery-3.2.1.min.js" integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4=" crossorigin="anonymous"></script>
+  <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.12.9/dist/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+  <script src="https://use.fontawesome.com/feff23b961.js"></script>
+  <script src="https://kit.fontawesome.com/2f4e00a49c.js" crossorigin="anonymous"></script>
+  <script src="https://code.jquery.com/jquery-3.2.1.js" integrity="sha256-DZAnKJ/6XZ9si04Hgrsxu/8s717jcIzLy3oi35EouyE=" crossorigin="anonymous"></script>
   <link rel="stylesheet" href="styles/metadata-qa.css">
   <script type="text/javascript">
     var marcBaseUrl = 'https://www.loc.gov/marc/bibliographic/';
@@ -32,8 +23,7 @@
       return marcBaseUrl + link;
     }
   </script>
-  <!-- script src="https://d3js.org/d3.v5.min.js"></script -->
-  <script src="./js/external-libs/d3.v5.min.js"></script>
+  <script src="https://d3js.org/d3.v5.min.js"></script>
 </head>
 <body>
 {if isset($error)}

--- a/templates/common/nav-tabs.tpl
+++ b/templates/common/nav-tabs.tpl
@@ -26,9 +26,19 @@
            id="completeness-tab" aria-controls="completeness"
            href="?tab=completeness{$generalParams}{if isset($groupId)}&groupId={$groupId}{/if}">{_('Completeness')}</a>
       {elseif $catalogue->getSchemaType() == 'UNIMARC'}
-        <a class="nav-link1 {if $tab == 'completeness'}active{/if}" data-toggle="tab1" role="tab1" aria-selected="false"
+        <a class="nav-link1 {if $isCompleteness}active{/if} dropdown-toggle"
+           data-toggle="dropdown" role="tab1" aria-selected="true"
            id="completeness-tab" aria-controls="completeness"
-           href="?tab=completeness{$generalParams}{if isset($groupId)}&groupId={$groupId}{/if}">{_('Completeness')}</a>
+           href="#">{_('Completeness')}</a>
+        <div class="dropdown-menu">
+          <a class="dropdown-item" href="?tab=completeness{$generalParams}">{_('Completeness')}</a>
+          <div class="dropdown-divider"></div>
+          <div style="padding: .25rem 1.5rem; color: #999999"><em>Weighted completeness versions</em></div>
+          <a class="dropdown-item" href="?tab=serials{$generalParams}"> &nbsp; Carlstone's serials analysis</a>
+          <a class="dropdown-item" href="?tab=tt-completeness{$generalParams}"> &nbsp; Thompson—Traill's e-book completeness</a>
+          <a class="dropdown-item" href="?tab=shelf-ready-completeness{$generalParams}"> &nbsp; Booth's shelf-ready completeness</a>
+          <a class="dropdown-item" href="?tab=functions{$generalParams}"> &nbsp; Functional analysis</a>
+        </div>
       {/if}
     </li>
     <li class="nav-item1">
@@ -63,11 +73,13 @@
            href="?tab=pareto{$generalParams}">Pareto</a>
       </li>
     {/if}
-    <li class="nav-item1">
-      <a class="nav-link1{if $tab == 'history'} active{/if}" data-toggle="tab1" role="tab1" aria-selected="false"
-         id="history-tab" aria-controls="history"
-         href="?tab=history{$generalParams}">{_('History')}</a>
-    </li>
+    {if $catalogue->getSchemaType() != 'UNIMARC'}
+      <li class="nav-item1">
+        <a class="nav-link1{if $tab == 'history'} active{/if}" data-toggle="tab1" role="tab1" aria-selected="false"
+           id="history-tab" aria-controls="history"
+           href="?tab=history{$generalParams}">{_('History')}</a>
+      </li>
+    {/if}
     {if !is_null($historicalDataDir)}
       <li class="nav-item1">
         <a class="nav-link1{if $tab == 'timeline'} active{/if}" data-toggle="tab1" role="tab1" aria-selected="false"

--- a/templates/data/unimarc/human-view.tpl
+++ b/templates/data/unimarc/human-view.tpl
@@ -16,28 +16,26 @@
 {include 'marc/773.tpl'}
 
 {* Electronic Location and Access *}
-{include 'marc/856.tpl'}
+{include 'unimarc/856.tpl'}
 
-{if $record->hasAuthorityNames() || $record->hasSubjectHeadings()}
+{if $record->hasAuthorityNames('UNIMARC') || $record->hasSubjectHeadings('UNIMARC')}
   <table class="authority-names">
-    {if $record->hasAuthorityNames()}
+    {if $record->hasAuthorityNames('UNIMARC')}
       <tr><td colspan="2" class="heading">Authority names</td></tr>
       {* TODO: 740, 751, 752, 753, 754, 800, 810, 811, 830 *}
-      {include 'marc/100.tpl'}{* Main personal names *}
-      {include 'marc/110.tpl'}{* Main corporate names *}
-      {include 'marc/111.tpl'}{* Main meeting names *}
-      {include 'marc/130.tpl'}{* Main meeting names *}
-      {include 'marc/700.tpl'}{* Additional personal names *}
-      {include 'marc/710.tpl'}{* Additional corporate names *}
-      {include 'marc/711.tpl'}{* Additional meeting names *}
-      {include 'marc/720.tpl'}{* uncontrolled name *}
-      {include 'marc/730.tpl'}{* Additional uniform title *}
-      {include 'marc/740.tpl'}{* Additional uniform title *}
+      {include 'unimarc/700.tpl'}{* Personal name - Primary responsibility *}
+      {include 'unimarc/701.tpl'}{* Personal name - Alternative responsibility *}
+      {include 'unimarc/702.tpl'}{* Personal name - Secondary responsibility *}
+      {include 'unimarc/710.tpl'}{* Coprorate body name - Primary responsibility *}
+      {include 'unimarc/711.tpl'}{* Coprorate body name - Alternative responsibility *}
+      {include 'unimarc/712.tpl'}{* Coprorate body name - Secondary responsibility *}
+      {include 'unimarc/730.tpl'}{* Name - entity responsible *}
     {/if}
 
-    {if $record->hasSubjectHeadings()}
+    {if $record->hasSubjectHeadings('UNIMARC')}
       <tr><td colspan="2" class="heading">Subjects</td></tr>
-      {* TODO: 055, 654, 656, 657, 658, 662 *}
+      {include 'unimarc/600.tpl'}{* Personal names as subjects *}
+      {include 'unimarc/601.tpl'}{* Corporate names as subjects *}
       {include 'marc/052.tpl'}{* geographic classification *}
       {include 'marc/072.tpl'}{* subject category code *}
       {include 'marc/080.tpl'}{* UDC *}
@@ -46,8 +44,6 @@
       {include 'marc/084.tpl'}{* other classifications *}
       {include 'marc/085.tpl'}{* synthesized classifications *}
       {include 'marc/086.tpl'}{* government document classifications *}
-      {include 'marc/600.tpl'}{* Personal names as subjects *}
-      {include 'marc/610.tpl'}{* Corporate names as subjects *}
       {include 'marc/611.tpl'}{* Meeting names as subjects *}
       {include 'marc/630.tpl'}{* Uniform title as subjects *}
       {include 'marc/647.tpl'}{* named event *}
@@ -61,8 +57,9 @@
 {/if}
 
 {* Cataloging Source *}
-{include 'marc/040.tpl'}
+{include 'unimarc/801.tpl'}
 
+{* This seems to be a MARC21-only approach, and that only for some specific local implementation with the field 912 *}
 {if $record->hasSimilarBooks()}
   <div class="similarity">
     <i class="fa fa-search" aria-hidden="true"></i>

--- a/templates/tt-completeness/tt-completeness-histogram.tpl
+++ b/templates/tt-completeness/tt-completeness-histogram.tpl
@@ -333,10 +333,6 @@ var count = {$count};
 var units = 'score';
 var fields = {json_encode($fields)};
 {literal}
-console.log(db);
-console.log(count);
-console.log(units);
-console.log(fields);
 
 var tooltip = d3.select("body")
   .append("div")

--- a/templates/tt-completeness/tt-completeness-histogram.tpl
+++ b/templates/tt-completeness/tt-completeness-histogram.tpl
@@ -333,6 +333,10 @@ var count = {$count};
 var units = 'score';
 var fields = {json_encode($fields)};
 {literal}
+console.log(db);
+console.log(count);
+console.log(units);
+console.log(fields);
 
 var tooltip = d3.select("body")
   .append("div")

--- a/templates/unimarc/600.tpl
+++ b/templates/unimarc/600.tpl
@@ -1,0 +1,37 @@
+{assign var="fieldInstances" value=$record->getFields('600')}
+{if !is_null($fieldInstances)}
+<tr>
+  <td><em>personal names</em>:</td>
+  <td>
+  {foreach from=$fieldInstances item=field}
+    <span class="600">
+      <i class="fa fa-hashtag" aria-hidden="true" title="Personal name"></i>
+      {*  Personal name *}
+      {foreach from=$field->subfields key=code item=value name=subfields}
+        {assign 'comma' value=(($smarty.foreach.subfields.last) ? '' : ',')}
+        {if $code == 'a'}
+          <a href="{$record->filter('600a_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'b'}
+          remaining part of name: <a href="{$record->filter('600b_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'c'}
+          additions to name: <a href="{$record->filter('600c_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'd'}
+          roman numerals: <a href="{$record->filter('600d_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'f'}
+          dates: <a href="{$record->filter('600f_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'g'}
+          expansion of initials: <a href="{$record->filter('600g_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 't'}
+          title: <a href="{$record->filter('600t_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == '2'}
+          source: {$value}{$comma}
+        {elseif $code == '3'}
+          authority ID: <a href="{$record->filter('6003_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {/if}
+      {/foreach}
+    </span>
+    <br/>
+  {/foreach}
+  </td>
+</tr>
+{/if}

--- a/templates/unimarc/601.tpl
+++ b/templates/unimarc/601.tpl
@@ -1,0 +1,39 @@
+{assign var="fieldInstances" value=$record->getFields('601')}
+{if !is_null($fieldInstances)}
+<tr>
+  <td><em>corporate body names</em>:</td>
+  <td>
+  {foreach from=$fieldInstances item=field}
+    <span class="601">
+      <i class="fa fa-hashtag" aria-hidden="true" title="Personal name"></i>
+      {*  Personal name *}
+      {foreach from=$field->subfields key=code item=value name=subfields}
+        {assign 'comma' value=(($smarty.foreach.subfields.last) ? '' : ',')}
+        {if $code == 'a'}
+          <a href="{$record->filter('601a_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'b'}
+          subdivision: <a href="{$record->filter('601b_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'c'}
+          addition to name: <a href="{$record->filter('601c_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'd'}
+          number of meeting: <a href="{$record->filter('601d_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'l'}
+          location of meeting: <a href="{$record->filter('601l_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'f'}
+          date of meeting: <a href="{$record->filter('601f_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'g'}
+          expansion of initials: <a href="{$record->filter('601g_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 't'}
+          title: <a href="{$record->filter('601t_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == '2'}
+          source: {$value}{$comma}
+        {elseif $code == '3'}
+          authority ID: <a href="{$record->filter('6013_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {/if}
+      {/foreach}
+    </span>
+    <br/>
+  {/foreach}
+  </td>
+</tr>
+{/if}

--- a/templates/unimarc/700.tpl
+++ b/templates/unimarc/700.tpl
@@ -1,0 +1,44 @@
+{assign var="fieldInstances" value=$record->getFields('700')}
+{if !is_null($fieldInstances)}
+<tr>
+  <td><em>personal names - primary responsibility</em>:</td>
+  <td>
+  {foreach from=$fieldInstances item=field}
+    <span class="700">
+      <i class="fa fa-user" aria-hidden="true" title="personal name"></i>
+      {foreach from=$field->subfields key=code item=value name=subfields}
+        {assign 'comma' value=(($smarty.foreach.subfields.last) ? '' : ',')}
+        {if $code == 'a'}
+          <a href="{$record->filter('700a_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'b'}
+          part of name: <a href="{$record->filter('700b_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'c'}
+          additions to names: <a href="{$record->filter('700c_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'd'}
+          roman numerals: <a href="{$record->filter('700d_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'f'}
+          dates: <a href="{$record->filter('700f_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'g'}
+          expansions of initials: <a href="{$record->filter('700g_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'k'}
+          attribution: <a href="{$record->filter('700k_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'o'}
+          international standard identifier: <a href="{$record->filter('700o_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'p'}
+          affiliation: <a href="{$record->filter('700p_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == '2'}
+          source: <a href="{$record->filter('7002_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == '3'}
+          authority ID: <a href="{$record->filter('7003_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == '4'}
+          relationship: <a href="{$record->filter('7004_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == '8'}
+          materials specified: <a href="{$record->filter('7008_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {/if}
+      {/foreach}
+    </span>
+    <br/>
+  {/foreach}
+    </td>
+  </tr>
+{/if}

--- a/templates/unimarc/701.tpl
+++ b/templates/unimarc/701.tpl
@@ -1,0 +1,44 @@
+{assign var="fieldInstances" value=$record->getFields('701')}
+{if !is_null($fieldInstances)}
+<tr>
+  <td><em>personal names - alternative responsibility</em>:</td>
+  <td>
+  {foreach from=$fieldInstances item=field}
+    <span class="701">
+      <i class="fa fa-user" aria-hidden="true" title="personal name"></i>
+      {foreach from=$field->subfields key=code item=value name=subfields}
+        {assign 'comma' value=(($smarty.foreach.subfields.last) ? '' : ',')}
+        {if $code == 'a'}
+          <a href="{$record->filter('701a_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'b'}
+          part of name: <a href="{$record->filter('701b_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'c'}
+          additions to names: <a href="{$record->filter('701c_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'd'}
+          roman numerals: <a href="{$record->filter('701d_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'f'}
+          dates: <a href="{$record->filter('701f_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'g'}
+          expansions of initials: <a href="{$record->filter('701g_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'k'}
+          attribution: <a href="{$record->filter('701k_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'o'}
+          international standard identifier: <a href="{$record->filter('701o_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'p'}
+          affiliation: <a href="{$record->filter('701p_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == '2'}
+          source: <a href="{$record->filter('7012_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == '3'}
+          authority ID: <a href="{$record->filter('7013_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == '4'}
+          relationship: <a href="{$record->filter('7014_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == '8'}
+          materials specified: <a href="{$record->filter('7018_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {/if}
+      {/foreach}
+    </span>
+    <br/>
+  {/foreach}
+    </td>
+  </tr>
+{/if}

--- a/templates/unimarc/702.tpl
+++ b/templates/unimarc/702.tpl
@@ -1,0 +1,45 @@
+{* 100a_MainPersonalName_personalName_ss *}
+{assign var="fieldInstances" value=$record->getFields('702')}
+{if !is_null($fieldInstances)}
+<tr>
+  <td><em>personal names - secondary responsibility</em>:</td>
+  <td>
+  {foreach from=$fieldInstances item=field}
+    <span class="701">
+      <i class="fa fa-user" aria-hidden="true" title="personal name"></i>
+      {foreach from=$field->subfields key=code item=value name=subfields}
+        {assign 'comma' value=(($smarty.foreach.subfields.last) ? '' : ',')}
+        {if $code == 'a'}
+          <a href="{$record->filter('702a_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'b'}
+          part of name: <a href="{$record->filter('702b_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'c'}
+          additions to names: <a href="{$record->filter('702c_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'd'}
+          roman numerals: <a href="{$record->filter('702d_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'f'}
+          dates: <a href="{$record->filter('702f_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'g'}
+          expansions of initials: <a href="{$record->filter('702g_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'k'}
+          attribution: <a href="{$record->filter('702k_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'o'}
+          international standard identifier: <a href="{$record->filter('702o_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'p'}
+          affiliation: <a href="{$record->filter('702p_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == '2'}
+          source: <a href="{$record->filter('7022_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == '3'}
+          authority ID: <a href="{$record->filter('7023_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == '4'}
+          relationship: <a href="{$record->filter('7024_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == '8'}
+          materials specified: <a href="{$record->filter('7028_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {/if}
+      {/foreach}
+    </span>
+    <br/>
+  {/foreach}
+    </td>
+  </tr>
+{/if}

--- a/templates/unimarc/710.tpl
+++ b/templates/unimarc/710.tpl
@@ -1,0 +1,44 @@
+{assign var="fieldInstances" value=$record->getFields('710')}
+{if !is_null($fieldInstances)}
+<tr>
+  <td><em>corporate body names - primary responsibility</em>:</td>
+  <td>
+  {foreach from=$fieldInstances item=field}
+    <span class="710">
+      <i class="fa fa-user" aria-hidden="true" title="corporate name"></i>
+      {foreach from=$field->subfields key=code item=value name=subfields}
+        {assign 'comma' value=(($smarty.foreach.subfields.last) ? '' : ',')}
+        {if $code == 'a'}
+          <a href="{$record->filter('710a_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'b'}
+          subdivision: <a href="{$record->filter('710b_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'c'}
+          additions to name: <a href="{$record->filter('710c_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'd'}
+          number of meeting: <a href="{$record->filter('710d_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'f'}
+          date of meeting: <a href="{$record->filter('710f_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'g'}
+          inverted element: <a href="{$record->filter('710g_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'h'}
+          remaining part of name: <a href="{$record->filter('710h_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'o'}
+          international standard identifier: <a href="{$record->filter('710o_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'p'}
+          affiliation: <a href="{$record->filter('710p_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == '2'}
+          source: <a href="{$record->filter('7102_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == '3'}
+          authority ID: <a href="{$record->filter('7103_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == '4'}
+          relationship: <a href="{$record->filter('7104_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == '8'}
+          materials specified: <a href="{$record->filter('7108_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {/if}
+      {/foreach}
+    </span>
+    <br/>
+  {/foreach}
+    </td>
+  </tr>
+{/if}

--- a/templates/unimarc/711.tpl
+++ b/templates/unimarc/711.tpl
@@ -1,0 +1,44 @@
+{assign var="fieldInstances" value=$record->getFields('711')}
+{if !is_null($fieldInstances)}
+<tr>
+  <td><em>corporate body names - alternative responsibility</em>:</td>
+  <td>
+  {foreach from=$fieldInstances item=field}
+    <span class="711">
+      <i class="fa fa-user" aria-hidden="true" title="corporate name"></i>
+      {foreach from=$field->subfields key=code item=value name=subfields}
+        {assign 'comma' value=(($smarty.foreach.subfields.last) ? '' : ',')}
+        {if $code == 'a'}
+          <a href="{$record->filter('711a_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'b'}
+          subdivision: <a href="{$record->filter('711b_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'c'}
+          additions to name: <a href="{$record->filter('711c_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'd'}
+          number of meeting: <a href="{$record->filter('711d_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'f'}
+          date of meeting: <a href="{$record->filter('711f_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'g'}
+          inverted element: <a href="{$record->filter('711g_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'h'}
+          remaining part of name: <a href="{$record->filter('711h_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'o'}
+          international standard identifier: <a href="{$record->filter('711o_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'p'}
+          affiliation: <a href="{$record->filter('711p_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == '2'}
+          source: <a href="{$record->filter('7112_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == '3'}
+          authority ID: <a href="{$record->filter('7113_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == '4'}
+          relationship: <a href="{$record->filter('7114_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == '8'}
+          materials specified: <a href="{$record->filter('7118_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {/if}
+      {/foreach}
+    </span>
+    <br/>
+  {/foreach}
+    </td>
+  </tr>
+{/if}

--- a/templates/unimarc/712.tpl
+++ b/templates/unimarc/712.tpl
@@ -1,0 +1,44 @@
+{assign var="fieldInstances" value=$record->getFields('712')}
+{if !is_null($fieldInstances)}
+<tr>
+  <td><em>corporate body names - secondary responsibility</em>:</td>
+  <td>
+  {foreach from=$fieldInstances item=field}
+    <span class="712">
+      <i class="fa fa-user" aria-hidden="true" title="corporate name"></i>
+      {foreach from=$field->subfields key=code item=value name=subfields}
+        {assign 'comma' value=(($smarty.foreach.subfields.last) ? '' : ',')}
+        {if $code == 'a'}
+          <a href="{$record->filter('712a_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'b'}
+          subdivision: <a href="{$record->filter('712b_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'c'}
+          additions to name: <a href="{$record->filter('712c_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'd'}
+          number of meeting: <a href="{$record->filter('712d_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'f'}
+          date of meeting: <a href="{$record->filter('712f_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'g'}
+          inverted element: <a href="{$record->filter('712g_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'h'}
+          remaining part of name: <a href="{$record->filter('712h_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'o'}
+          international standard identifier: <a href="{$record->filter('712o_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'p'}
+          affiliation: <a href="{$record->filter('712p_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == '2'}
+          source: <a href="{$record->filter('7122_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == '3'}
+          authority ID: <a href="{$record->filter('7123_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == '4'}
+          relationship: <a href="{$record->filter('7124_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == '8'}
+          materials specified: <a href="{$record->filter('7128_ss', $value)}" class="record-link">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {/if}
+      {/foreach}
+    </span>
+    <br/>
+  {/foreach}
+    </td>
+  </tr>
+{/if}

--- a/templates/unimarc/730.tpl
+++ b/templates/unimarc/730.tpl
@@ -1,0 +1,15 @@
+{assign var="fieldInstances" value=$record->getFields('730')}
+{if !is_null($fieldInstances)}
+<tr>
+  <td><em>uniform title</em>:</td>
+  <td>
+  {foreach from=$fieldInstances item=field}
+    <span class="730">
+      <i class="fa fa-user" aria-hidden="true" title="name - entity responsible"></i>
+      <a href="{$record->filter('730a_ss', $field->subfields->a)}" class="record-link" title="name - entity responsible">{include 'data/subfield.tpl' value=$field->subfields->a}</a>
+    </span>
+    <br/>
+  {/foreach}
+  </td>
+</tr>
+{/if}

--- a/templates/unimarc/801.tpl
+++ b/templates/unimarc/801.tpl
@@ -1,0 +1,22 @@
+{* 100a_MainPersonalName_personalName_ss *}
+{assign var="fieldInstances" value=$record->getFields('801')}
+{if !is_null($fieldInstances)}
+  <em>Originating Source:</em>
+  {foreach from=$fieldInstances item=field}
+    <span class="040">
+      {foreach from=$field->subfields key=code item=value name=subfields}
+        {assign 'comma' value=(($smarty.foreach.subfields.last) ? '' : ',')}
+        {if $code=='a'}
+          <em>country:</em> <span class="country">{include 'data/subfield.tpl' value=$value}</span>{$comma}
+        {elseif $code == 'b'}
+          <em>original cataloging agency:</em> <a href="{$record->filter('801b_ss', $value)}" class="cataloging">{include 'data/subfield.tpl' value=$value}</a>{$comma}
+        {elseif $code == 'c'}
+          <em>date:</em> <span class="date">{include 'data/subfield.tpl' value=$value}</span>{$comma}
+        {elseif $code == 'g'}
+          <em>description conventions:</em> <span class="conventions">{include 'data/subfield.tpl' value=$value}</span>{$comma}
+        {/if}
+      {/foreach}
+    </span>
+    <br/>
+  {/foreach}
+{/if}

--- a/templates/unimarc/856.tpl
+++ b/templates/unimarc/856.tpl
@@ -1,0 +1,61 @@
+{* Electronic Location and Access, https://www.loc.gov/marc/bibliographic/bd856.html *}
+{assign var="fieldInstances" value=$record->getFields('856')}
+{if !is_null($fieldInstances)}
+  {assign var="count" value="{count($fieldInstances)}"}
+  <p>
+    {if $count > 1}<em>Links:</em><ul class="list-856">{/if}
+    {foreach from=$fieldInstances item=field name="fields"}
+      {if $count > 1}<li>{/if}
+      <span class="856">
+        {if isset($field->subfields->u)}
+          <span class="" title="Link">
+            <a href="{$field->subfields->u}" target="_blank">
+              {if property_exists($field->subfields, '2')}{include 'data/subfield.tpl' value=$field->subfields->{'2'}}{else}{include 'data/subfield.tpl' value=$field->subfields->u}{/if}
+            </a>
+          </span>
+        {/if}
+        {if isset($field->subfields->q)}
+          (<em>format:</em> <span class="" title="Electronic format type">{include 'data/subfield.tpl' value=$field->subfields->q}</span>)
+        {/if}
+        {if isset($field->subfields->a)}
+          <span class="host-name" title="Host name"><em>{include 'data/subfield.tpl' value=$field->subfields->a}</em></span>,
+        {/if}
+        {if isset($field->subfields->c)}
+          <span class="" title="Compression information">{include 'data/subfield.tpl' value=$field->subfields->c}</span>,
+        {/if}
+        {if isset($field->subfields->d)}
+          <span class="" title="Path">{include 'data/subfield.tpl' value=$field->subfields->d}</span>,
+        {/if}
+        {if isset($field->subfields->f)}
+          <span class="" title="Electronic name">{include 'data/subfield.tpl' value=$field->subfields->f}</span>,
+        {/if}
+        {if isset($field->subfields->m)}
+          <em>contact:</em> <span class="" title="Contact for access assistance">{include 'data/subfield.tpl' value=$field->subfields->m}</span>,
+        {/if}
+        {if isset($field->subfields->o)}
+          <span class="" title="Operating system">{include 'data/subfield.tpl' value=$field->subfields->o}</span>,
+        {/if}
+        {if isset($field->subfields->p)}
+          <span class="" title="Port">{include 'data/subfield.tpl' value=$field->subfields->p}</span>,
+        {/if}
+        {if isset($field->subfields->s)}
+          <span class="" title="File size">{include 'data/subfield.tpl' value=$field->subfields->s}</span>,
+        {/if}
+        {if isset($field->subfields->v)}
+          <span class="title" title="Hours access method available">{include 'data/subfield.tpl' value=$field->subfields->v}</span>,
+        {/if}
+        {if isset($field->subfields->x)}
+          <em>nonpublic note:</em> <span class="" title="Nonpublic note">{include 'data/subfield.tpl' value=$field->subfields->x}</span>,
+        {/if}
+        {if isset($field->subfields->z)}
+          <em>public note:</em> <span class="" title="Public note">{include 'data/subfield.tpl' value=$field->subfields->z}</span>,
+        {/if}
+        {if isset($field->subfields->y)}
+          (<span class="" title="Access method">{include 'data/subfield.tpl' value=isset($field->subfields->y)}</span>),
+        {/if}
+      </span>
+      {if $count > 1}</li>{/if}
+    {/foreach}
+    {if $count > 1}</ul>{/if}
+  <p>
+{/if}


### PR DESCRIPTION
This pull request consists of some small modifications that enable integrating UNIMARC into the QA-Catalogue-Web project.

It mostly consists of minor changes like: Methods to set UNIMARC facets in the Authorities and Subject classification classes; Additional templates in data preview interfaces; Minor and occasional code refactorings.

One important thing to note is that I disabled the 'History' navigation button for UNIMARC temporarily, as date extraction (Formatter.java) in the QA-Catalogue project works differently than for MARC21. In MARC21, the dates are directly in positions of the field 008, whereas for UNIMARC it's in the positions of the subfield $a of the field 100. For now, the Formatter class cannot extract exact positions from subfields (only from control fields like 008), which means this is temporarily disabled for UNIMARC.