### PR TITLE
Add configuration parameter include: check if the key is existing in …

### DIFF
--- a/classes/Utils/Configuration.php
+++ b/classes/Utils/Configuration.php
@@ -40,7 +40,7 @@ class Configuration {
       throw new Exception("failed to read config file!");
     }
 
-    if ($ini['include'] && file_exists($ini['include'])) {
+    if (isset($ini['include']) && file_exists($ini['include'])) {
       $include = @parse_ini_file($ini['include'], false, INI_SCANNER_TYPED);
       if (!$include) {
         throw new Exception("failed to include config file!");


### PR DESCRIPTION
…the config (#181)

* 045Q/01 (Basisklassifikation) is not displayed at the Sacherschließung page #178

* Don't show \!\! when footer missing

* Add configuration parameter `include`

* Turn on/off the git connection feature by configuration #179

* Add configuration parameter : check if the key is existing in the config

---------